### PR TITLE
Fix: Correctly render triangles on hexagon tile edges

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,6 +137,11 @@ main {
     /* Base width of triangle: 36.95px (approx 37px) */
     /* Height of triangle (arbitrary, e.g., 10px) */
     /* Using border technique: width is 0, height is 0 */
+    width: 0;
+    height: 0;
+    border-left: 18.475px solid transparent; /* TBW/2 */
+    border-right: 18.475px solid transparent; /* TBW/2 */
+    border-bottom: 10px solid black; /* TH and color */
     /* The border perpendicular to the direction of the triangle defines its height */
     /* The borders parallel to the direction define half its base */
 }
@@ -147,7 +152,7 @@ Tile Width (flat-to-flat): 80px (let's call it W)
 Tile Height (vertex-to-vertex): 92.38px (let's call it H)
 Side Length (S): 46.19px (H/2 or W/sqrt(3))
 
-Triangle Base Width (TBW): 0.8 * S = 36.95px
+Triangle Base Width (TBW): 0.8 * S = 36.95px (Using approx 37px for calculations)
 Triangle Height (TH): Let's choose 10px for visual appearance.
 
 For .edge-blank, we'll create a line.
@@ -155,88 +160,75 @@ Line Width (LW): TBW = 36.95px
 Line Thickness (LT): 2px
 */
 
-/* This is becoming overly complex due to combined translation and rotation of individual elements.
-   A better approach is to use absolute positioning for each edge's container,
-   and then inside that container, the triangle/blank is simpler.
-   Or, use transform on the .edge-N container to place its origin, then simple offset for content.
-
-   Let's simplify the positioning strategy for edges.
+/* Positioning strategy for edges:
    Each edge container (.edge-N) will be positioned at the center of the hexagon tile.
    Then, we use translate and rotate to move it to the edge and orient it.
+   The triangle itself (.edge-triangle) is defined to point "up" (border-bottom creates the shape).
+   Rotations will correctly orient this upward-pointing triangle.
 */
 
-/* Resetting edge positioning strategy */
 .edge-0, .edge-1, .edge-2, .edge-3, .edge-4, .edge-5 {
+    position: absolute; /* Ensure this is set for the edge containers if not already */
     left: 50%;
     top: 50%;
-    /* Base transform will be set per edge number */
+    /* transform-origin: center center; */ /* Default, but good to be explicit if needed */
 }
 
 /* Edge 0: Top */
-/* Translate Y by -H/2 to reach top center of hexagon. Then move triangle/line further out. */
+/* Triangle points up. Needs to be moved to top edge. Translate Y by -(SideLength + TriangleHeight/2) approx */
+/* More accurately, translate Y by -(HexRadius + TriangleHeight) then adjust. HexRadius = SideLength = H/2 */
 .edge-0.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) translateY(calc(-46.19px)) translateY(-1px); /* H/2, LT/2 */
+    transform: translate(-50%, -50%) translateY(calc(-46.19px + 1px)); /* Centered on edge */
 }
 .edge-0.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
-    transform: translate(-50%, -50%) translateY(calc(-46.19px - 10px)); /* H/2, TH */
+    /* Default triangle points up, border-bottom is the base. We want it to point outwards. */
+    /* So for edge 0 (top), it should point up. translateY moves it. */
+    transform: translate(-50%, -50%) translateY(calc(-46.19px - 10px)); /* S + TH */
 }
 
 /* Edge 1: Top-Right */
-/* Rotate by 60 deg. Then translate Y by -H/2. Then move triangle/line further out. */
 .edge-1.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) rotate(60deg) translateY(calc(-46.19px)) translateY(-1px);
+    transform: translate(-50%, -50%) rotate(60deg) translateY(calc(-46.19px + 1px));
 }
 .edge-1.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
-    /* The triangle itself needs to be rotated if its "border-bottom" is to be the base pointing outwards */
-    /* This means the triangle's "natural" orientation (e.g. point up with border-bottom) must be rotated. */
-    transform: translate(-50%, -50%) rotate(60deg) translateY(calc(-46.19px - 10px)) ;
+    transform: translate(-50%, -50%) rotate(60deg) translateY(calc(-46.19px - 10px));
 }
 
 /* Edge 2: Bottom-Right */
-/* Rotate by 120 deg. Then translate Y by -H/2. */
 .edge-2.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) rotate(120deg) translateY(calc(-46.19px)) translateY(-1px);
+    transform: translate(-50%, -50%) rotate(120deg) translateY(calc(-46.19px + 1px));
 }
 .edge-2.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
     transform: translate(-50%, -50%) rotate(120deg) translateY(calc(-46.19px - 10px));
 }
 
 /* Edge 3: Bottom */
-/* Rotate by 180 deg. Then translate Y by -H/2. */
 .edge-3.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) rotate(180deg) translateY(calc(-46.19px)) translateY(-1px);
+    transform: translate(-50%, -50%) rotate(180deg) translateY(calc(-46.19px + 1px));
 }
 .edge-3.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
     transform: translate(-50%, -50%) rotate(180deg) translateY(calc(-46.19px - 10px));
 }
 
 /* Edge 4: Bottom-Left */
-/* Rotate by 240 deg. Then translate Y by -H/2. */
 .edge-4.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) rotate(240deg) translateY(calc(-46.19px)) translateY(-1px);
+    transform: translate(-50%, -50%) rotate(240deg) translateY(calc(-46.19px + 1px));
 }
 .edge-4.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
     transform: translate(-50%, -50%) rotate(240deg) translateY(calc(-46.19px - 10px));
 }
 
 /* Edge 5: Top-Left */
-/* Rotate by 300 deg. Then translate Y by -H/2. */
 .edge-5.edge-blank {
     width: 36.95px; height: 2px; background-color: #555;
-    transform: translate(-50%, -50%) rotate(300deg) translateY(calc(-46.19px)) translateY(-1px);
+    transform: translate(-50%, -50%) rotate(300deg) translateY(calc(-46.19px + 1px));
 }
 .edge-5.edge-triangle {
-    border-left: 18.475px solid transparent; border-right: 18.475px solid transparent; border-bottom: 10px solid black;
     transform: translate(-50%, -50%) rotate(300deg) translateY(calc(-46.19px - 10px));
 }
 


### PR DESCRIPTION
- Simplified CSS for triangle rendering using the border technique.
- Adjusted transform properties to ensure accurate positioning of triangles and blank edge indicators on the hexagon edges.