### PR TITLE
Fix: Remove duplicate UNIQUE_TILE_PATTERNS declaration

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,22 +85,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Tile Generation ---
-    const UNIQUE_TILE_PATTERNS = [
-        [0,0,0,0,0,0], // 0 triangles
-        [1,0,0,0,0,0], // 1 triangle
-        [1,1,0,0,0,0], // 2 triangles, adjacent
-        [1,0,1,0,0,0], // 2 triangles, separated by 1
-        [1,0,0,1,0,0], // 2 triangles, separated by 2 (opposite)
-        [1,1,1,0,0,0], // 3 triangles, block of 3
-        [1,1,0,1,0,0], // 3 triangles, pattern 110100
-        [1,0,1,1,0,0], // 3 triangles, pattern 101100 (or rotated 110010)
-        [1,0,1,0,1,0], // 3 triangles, alternating
-        [1,1,1,1,0,0], // 4 triangles (complement of 2 blanks adjacent)
-        [1,1,0,1,1,0], // 4 triangles (complement of 2 blanks separated by 1)
-        [1,0,1,1,0,1], // 4 triangles (complement of 2 blanks separated by 2, e.g. 110101)
-        [1,1,1,1,1,0], // 5 triangles
-        [1,1,1,1,1,1]  // 6 triangles
-    ];
+    // const UNIQUE_TILE_PATTERNS = [  // This is a duplicate, removing
+    //     [0,0,0,0,0,0], // 0 triangles
+    //     [1,0,0,0,0,0], // 1 triangle
+    //     [1,1,0,0,0,0], // 2 triangles, adjacent
+    //     [1,0,1,0,0,0], // 2 triangles, separated by 1
+    //     [1,0,0,1,0,0], // 2 triangles, separated by 2 (opposite)
+    //     [1,1,1,0,0,0], // 3 triangles, block of 3
+    //     [1,1,0,1,0,0], // 3 triangles, pattern 110100
+    //     [1,0,1,1,0,0], // 3 triangles, pattern 101100 (or rotated 110010)
+    //     [1,0,1,0,1,0], // 3 triangles, alternating
+    //     [1,1,1,1,0,0], // 4 triangles (complement of 2 blanks adjacent)
+    //     [1,1,0,1,1,0], // 4 triangles (complement of 2 blanks separated by 1)
+    //     [1,0,1,1,0,1], // 4 triangles (complement of 2 blanks separated by 2, e.g. 110101)
+    //     [1,1,1,1,1,0], // 5 triangles
+    //     [1,1,1,1,1,1]  // 6 triangles
+    // ];
 
     function generateUniqueTilesForPlayer(playerId, count) {
         const tiles = [];


### PR DESCRIPTION
The variable UNIQUE_TILE_PATTERNS was declared twice, causing a syntax error. This commit removes the duplicate declaration.