### PR TITLE
feat: Add AI player for Player 2 with random moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
             <p id="game-message"></p>
             <p id="player1-score">Player 1 Score: 0</p>
             <p id="player2-score">Player 2 Score: 0</p>
+            <div id="ai-toggle-container">
+                <label for="ai-toggle">Play against AI (Player 2):</label>
+                <input type="checkbox" id="ai-toggle">
+            </div>
         </div>
 
         <canvas id="game-canvas" width="600" height="500"></canvas>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,25 @@ main {
     margin: 5px 0;
 }
 
+#ai-toggle-container {
+    margin-top: 10px;
+    padding: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#ai-toggle-container label {
+    margin-right: 8px;
+    font-size: 0.9em;
+}
+
+#ai-toggle {
+    /* Style the checkbox itself if desired, or use default browser styling */
+    transform: scale(1.2); /* Makes the checkbox slightly larger */
+    margin-right: 5px;
+}
+
 /* Style for the canvas if needed, e.g., centering or border */
 #game-canvas {
     display: block; /* To enable margin auto for centering */


### PR DESCRIPTION
- Adds a toggle switch to enable/disable AI for Player 2.
- When active, the AI selects a random tile, rotates it randomly, and places it in a random valid position.
- AI can also handle the tile removal phase if its move or the opponent's move results in surrounded tiles during its turn to act.