### PR TITLE
Feat: Change placement highlight to shaded fill

### DIFF
--- a/script.js
+++ b/script.js
@@ -544,17 +544,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         ctx.closePath();
 
-        ctx.strokeStyle = color;
-        ctx.lineWidth = isDeemphasized ? 2 : 3; // Thinner line for de-emphasized
+        // ctx.strokeStyle = color; // No longer stroking
+        // ctx.lineWidth = isDeemphasized ? 2 : 3; // Not needed for fill
 
-        if (isDeemphasized) {
-            ctx.setLineDash([5, 5]); // Dashed line for de-emphasized
-        } else {
-            ctx.setLineDash([]); // Solid line for normal highlight
-        }
+        // if (isDeemphasized) { // Line dash not applicable to fill
+        //     ctx.setLineDash([5, 5]);
+        // } else {
+        //     ctx.setLineDash([]);
+        // }
 
-        ctx.stroke();
-        ctx.setLineDash([]); // Reset line dash for subsequent drawing operations
+        ctx.fillStyle = color; // Use the provided color, which should have alpha
+        ctx.fill();
+        // ctx.setLineDash([]); // Not needed
     }
 
 


### PR DESCRIPTION
Modified the drawPlacementHighlight function in script.js to use a filled hexagon (ctx.fill()) instead of an outline (ctx.stroke()) for indicating possible tile placement locations.

- Changed ctx.stroke() to ctx.fill().
- Used ctx.fillStyle with the existing highlight colors (which include alpha transparency).
- Removed unused stroke-specific properties like lineWidth and setLineDash from the function.

This change improves the visibility of placement options on the game board.