### PR TITLE
Add Greedy 2 CPU with 1-ply lookahead and removal simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                     <option value="human">Human</option>
                     <option value="random">Random (CPU)</option>
                     <option value="greedy">Greedy 1 (CPU)</option>
+                    <option value="greedy2">Greedy 2 (CPU)</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
Implemented a new AI opponent 'Greedy 2 (CPU)' that uses a minimax algorithm to look one move ahead (AI's move + opponent's best response).

Key features:
- Simulates tile placement for AI and opponent.
- Simulates the tile removal process strategically within the minimax evaluation for both AI and opponent turns.
- The AI's actual tile removal (when it's its turn to remove a tile on the board) is now also strategic for Greedy 2, choosing the removal that maximizes its score.
- Helper functions for getting all possible moves, evaluating the board, and deep copying game states were added/refined to support the minimax logic.
- HTML updated to include 'Greedy 2 (CPU)' in the opponent selector.