### PR TITLE
Fix: Update gameboard view after AI Player 2 moves

### DIFF
--- a/script.js
+++ b/script.js
@@ -1553,6 +1553,9 @@ function animateView() {
                 console.log(`AI (${opponentType}): Successfully placed tile ${tileToPlace.id}.`);
                 gameMessageDisplay.textContent = `Player 2 (AI) placed tile.`;
                 checkForSurroundedTilesAndProceed();
+                // Ensure view updates after AI move and any subsequent actions (like tile removal) are complete.
+                updateViewParameters();
+                animateView();
             } else {
                 // This should not happen if isPlacementValid was checked correctly during simulation
                 console.error(`AI (${opponentType}): Failed to place tile ${tileToPlace.id} despite it being considered a valid move.`);


### PR DESCRIPTION
Ensures that the gameboard centering and zoom are updated after Player 2 (AI) completes its move, including any tile removals.

Previously, the view would not update if the AI made a move that didn't result in tile removals. This change adds calls to updateViewParameters() and animateView() at the end of the AI's move processing in `performAiMove`, similar to how it's handled for human player moves.

This ensures a consistent user experience where the board always adjusts to the current state of play after any player's turn.