### PR TITLE
Fix: Center board view based on pixel bounding box to prevent drift

### DIFF
--- a/script.js
+++ b/script.js
@@ -1217,9 +1217,20 @@ function updateViewParameters() {
         targetZoomLevel = Math.min(targetZoomLevel, 0.8); // Ensure initial zoom is not too large
     }
 
-    const scaledSideLength = BASE_HEX_SIDE_LENGTH * targetZoomLevel;
-    targetOffsetX = gameCanvas.width / 2 - scaledSideLength * (3/2 * boundingBoxCenterQ);
-    targetOffsetY = gameCanvas.height / 2 - scaledSideLength * (Math.sqrt(3)/2 * boundingBoxCenterQ + Math.sqrt(3) * boundingBoxCenterR);
+    // const scaledSideLength = BASE_HEX_SIDE_LENGTH * targetZoomLevel; // Kept for reference, but not used in the new offset calculation directly here.
+    // targetOffsetX = gameCanvas.width / 2 - scaledSideLength * (3/2 * boundingBoxCenterQ); // Old centering logic
+    // targetOffsetY = gameCanvas.height / 2 - scaledSideLength * (Math.sqrt(3)/2 * boundingBoxCenterQ + Math.sqrt(3) * boundingBoxCenterR); // Old centering logic
+
+    // Calculate the width and height of the content *at the target zoom level*
+    const contentPixelWidthAtTargetZoom = totalPixelWidthNeeded * targetZoomLevel;
+    const contentPixelHeightAtTargetZoom = totalPixelHeightNeeded * targetZoomLevel;
+
+    // New offset calculation to center the pixel bounding box
+    // This ensures that the actual rendered pixel content is centered.
+    // minPixelX and minPixelY are the coordinates of the top-left of the content's bounding box *at zoom 1.0*.
+    // We need to account for the current targetZoomLevel.
+    targetOffsetX = (gameCanvas.width - contentPixelWidthAtTargetZoom) / 2 - (minPixelX * targetZoomLevel);
+    targetOffsetY = (gameCanvas.height - contentPixelHeightAtTargetZoom) / 2 - (minPixelY * targetZoomLevel);
 }
 
 let animationFrameId = null; // To keep track of the animation frame


### PR DESCRIPTION
Previously, the board view offset was calculated by centering the logical center of the tiles on the canvas. This could lead to a visual "drift", especially downwards, as the board grew, causing unbalanced margins and potentially cutting off elements at the bottom.

This commit modifies the `updateViewParameters` function to calculate the view offset by centering the actual pixel bounding box of the rendered content. This ensures that the board remains visually centered regardless of its size or the distribution of tiles, providing a more stable and user-friendly viewing experience.