### PR TITLE
Fix: Position score display at bottom right of gameboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,12 @@
     </header>
 
     <main>
-        <canvas id="game-canvas" width="600" height="500"></canvas>
-        <!-- Consider styling the canvas (e.g., border) via CSS if needed -->
-        <div id="player-scores">
-            <!-- Scores will be populated here by script.js -->
+        <div id="gameboard-area">
+            <canvas id="game-canvas" width="600" height="500"></canvas>
+            <!-- Consider styling the canvas (e.g., border) via CSS if needed -->
+            <div id="player-scores">
+                <!-- Scores will be populated here by script.js -->
+            </div>
         </div>
 
         <div id="player-hands">

--- a/style.css
+++ b/style.css
@@ -21,7 +21,17 @@ main {
     width: 90%;
     max-width: 1200px;
     margin: 20px auto;
-    position: relative; /* Added for positioning player-scores */
+    position: relative; /* Added for positioning player-scores - this can likely be removed if gameboard-area handles it */
+}
+
+#gameboard-area {
+    position: relative;
+    /* The width and height of this container will be determined by its content, primarily the canvas.
+       If the canvas has a fixed size, this container will wrap it.
+       Alternatively, we could set a width/height or max-width/height here if needed.
+       For now, let's assume the canvas size dictates the gameboard-area size. */
+    margin: 0 auto; /* Center the gameboard area if its width is less than main's width */
+    /* display: inline-block; might be useful if canvas is also inline-block and we want them to size together */
 }
 
 /* Removed #game-info styles */


### PR DESCRIPTION
Moved the player scores to be correctly positioned at the bottom right of the game canvas by introducing a new container div `gameboard-area` that wraps the canvas and scores, and serves as the relative positioning context.