### PR TITLE
Fix: Game ends when player starts turn with empty hand

### DIFF
--- a/script.js
+++ b/script.js
@@ -856,11 +856,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 isRemovingTiles = false; // Ensure it's reset if no tiles were surrounded
                 calculateScores(); // Update scores after each turn
-                if (checkGameEnd()) {
-                    endGame();
-                } else {
-                    switchTurn();
-                }
+                switchTurn(); // Always switch turn, game end is checked at the start of the next turn
             }
         }
 


### PR DESCRIPTION
The game was previously ending immediately when a player emptied their hand. This change ensures the game only ends if a player *starts* their turn with no tiles, allowing the other player a final turn as per the rules.