### PR TITLE
Fix: Adjust preview hexagon border to prevent overlap

### DIFF
--- a/script.js
+++ b/script.js
@@ -639,7 +639,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // effectively pulling the center of the line inwards.
         // A common way is to reduce radius by half the line width.
         // For a hexagon, the relationship between side length and "radius" (center to vertex) is direct.
-        const borderHexSideLength = originalScaledHexSideLength - (borderWidth / 2);
+        // To make the border fully inset, subtract the full borderWidth.
+        const borderHexSideLength = originalScaledHexSideLength - borderWidth;
 
         ctx.beginPath();
         for (let i = 0; i < 6; i++) {


### PR DESCRIPTION
The preview hexagon's border was previously calculated to be inset by half its width. This caused the outer edge of the border to align with the actual placement boundary, potentially overlapping the borders of adjacent played hexagons.

This change modifies the `borderHexSideLength` calculation in `drawPlacementPreview` to subtract the full `borderWidth`. This ensures the entire preview border is drawn inside the conceptual space of the hexagon, making it appear slightly smaller and preventing any visual overlap with other elements on the board.