### PR TITLE
Fix: Center gameboard on narrow screens by making canvas responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,6 +90,8 @@ main {
     display: block; /* To enable margin auto for centering */
     margin: 20px auto;
     /* border: 1px solid black; */ /* Example border, JS draws one now */
+    max-width: 100%; /* Allow canvas to shrink on smaller screens */
+    height: auto; /* Maintain aspect ratio when width changes */
 }
 
 /* .board-cell is obsolete */


### PR DESCRIPTION
The gameboard canvas had a fixed width of 600px, causing it to overflow on screens narrower than this width. This change makes the canvas responsive:

- Added `max-width: 100%` to `#game-canvas` so it can shrink to fit its container.
- Added `height: auto` to `#game-canvas` to maintain its aspect ratio when its width changes.

The existing `margin: auto` rules on the canvas and its parent containers will now correctly center the gameboard with symmetrical margins on all screen sizes.