### PR TITLE
Fix: Correct hexagonal scan radius in AI worker

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -290,7 +290,8 @@ function workerPerformAiMove(boardState, player2HandOriginal, player1HandOrigina
                         const scanRadius = 3;
                         for (let q = -scanRadius; q <= scanRadius; q++) {
                             for (let r = -scanRadius; r <= scanRadius; r++) {
-                                 if (Math.abs(q + r) > scanRadius) continue;
+                                 // Corrected condition for axial hex radius
+                                 if ((Math.abs(q) + Math.abs(r) + Math.abs(q + r)) / 2 > scanRadius) continue;
                                  const spotKey = `${q},${r}`;
                                  if(!boardState[spotKey] && !checkedSpots.has(spotKey)){
                                      placementSpots.push({ x: q, y: r });
@@ -446,7 +447,8 @@ function getAllPossibleMoves(currentBoardState, hand, playerId) {
                         const scanRadius = 3;
                         for (let q = -scanRadius; q <= scanRadius; q++) {
                             for (let r = -scanRadius; r <= scanRadius; r++) {
-                                if (Math.abs(q + r) > scanRadius) continue;
+                                // Corrected condition for axial hex radius
+                                if ((Math.abs(q) + Math.abs(r) + Math.abs(q + r)) / 2 > scanRadius) continue;
                                 const spotKey = `${q},${r}`;
                                 if (!currentBoardState[spotKey]) {
                                     placementSpots.add(spotKey);


### PR DESCRIPTION
The previous scan radius condition for fallback placement spot generation in the 'greedy' and 'greedy2' AIs was incorrect for axial coordinates. This commit corrects the condition to use the proper hexagonal distance calculation.

This should reduce the likelihood of the AI considering invalid or distant spots that could lead to placement errors like the one reported for 'p2t6'.