### PR TITLE
Fix Greedy 2 AI tile placement error by standardizing move object

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -256,10 +256,15 @@ function workerPerformAiMove(boardState, player2HandOriginal, player1HandOrigina
             index === self.findIndex((p) => p.x === pos.x && p.y === pos.y)
         );
         if (uniquePlacements.length > 0) {
-            bestMove = uniquePlacements[Math.floor(Math.random() * uniquePlacements.length)];
+            const chosenPlacement = uniquePlacements[Math.floor(Math.random() * uniquePlacements.length)];
+            bestMove = {
+                tileId: chosenPlacement.tile.id,
+                orientation: chosenPlacement.orientation, // This was tileToPlay.orientation from the placement
+                x: chosenPlacement.x,
+                y: chosenPlacement.y
+            };
         }
         tileToPlay.orientation = originalOrientation; // Restore
-         if (bestMove) bestMove.tile = {id: bestMove.tile.id, orientation: bestMove.orientation}; // Send back minimal tile info
 
     } else if (opponentType === 'greedy') {
         // console.log("[Worker] AI: Playing Greedily");
@@ -334,9 +339,9 @@ function workerPerformAiMove(boardState, player2HandOriginal, player1HandOrigina
                         const scoreDiff = scores.player2Score - scores.player1Score;
                         if (scoreDiff > bestScoreDiff) {
                             bestScoreDiff = scoreDiff;
-                            bestMoves = [{ tile: {id: tile.id, orientation: tile.orientation}, x: pos.x, y: pos.y, score: scoreDiff }];
+                            bestMoves = [{ tileId: tile.id, orientation: tile.orientation, x: pos.x, y: pos.y, score: scoreDiff }];
                         } else if (scoreDiff === bestScoreDiff) {
-                            bestMoves.push({ tile: {id: tile.id, orientation: tile.orientation}, x: pos.x, y: pos.y, score: scoreDiff });
+                            bestMoves.push({ tileId: tile.id, orientation: tile.orientation, x: pos.x, y: pos.y, score: scoreDiff });
                         }
                     }
                 }
@@ -344,6 +349,7 @@ function workerPerformAiMove(boardState, player2HandOriginal, player1HandOrigina
             tile.orientation = originalOrientation;
         }
         if (bestMoves.length > 0) {
+            // bestMove is already in the desired format {tileId, orientation, x, y, score}
             bestMove = bestMoves[Math.floor(Math.random() * bestMoves.length)];
         }
 
@@ -352,8 +358,15 @@ function workerPerformAiMove(boardState, player2HandOriginal, player1HandOrigina
         // console.log("[Worker] AI: Playing Greedily with Lookahead (Greedy 2)");
         const minimaxResult = findBestMoveMinimax(boardState, player2Hand, player1Hand, currentPlayerId, (currentPlayerId % 2) + 1, 1); // depth 1
         if (minimaxResult && minimaxResult.moves && minimaxResult.moves.length > 0) {
-            bestMove = minimaxResult.moves[Math.floor(Math.random() * minimaxResult.moves.length)];
-            // bestMove.tile is already {id, orientation} from minimax
+            const chosenMinimaxMove = minimaxResult.moves[Math.floor(Math.random() * minimaxResult.moves.length)];
+            // Transform the structure from findBestMoveMinimax
+            bestMove = {
+                tileId: chosenMinimaxMove.tile.id,
+                orientation: chosenMinimaxMove.tile.orientation,
+                x: chosenMinimaxMove.x,
+                y: chosenMinimaxMove.y,
+                score: chosenMinimaxMove.score // Keep score if needed for debugging or future use
+            };
         }
     }
 

--- a/script.js
+++ b/script.js
@@ -1249,13 +1249,13 @@ function isSpaceEnclosed(q, r, currentBoardState) {
         // console.log("[Main] Received AI move result from worker:", move);
         if (player2HandContainer) player2HandContainer.classList.remove('ai-thinking-pulse');
 
-        if (move && move.tile) {
-            const tileToPlace = player2Hand.find(t => t.id === move.tile.id);
+        if (move && typeof move.tileId !== 'undefined' && typeof move.orientation !== 'undefined') {
+            const tileToPlace = player2Hand.find(t => t.id === move.tileId);
             if (!tileToPlace) {
-                console.error(`[Main] AI Error: Best move tile (ID: ${move.tile.id}) not found in player 2 hand.`);
+                console.error(`[Main] AI Error: Best move tile (ID: ${move.tileId}) not found in player 2 hand.`);
                 switchTurn(); return;
             }
-            tileToPlace.orientation = move.orientation;
+            tileToPlace.orientation = move.orientation; // Use the standardized top-level orientation
 
             console.log(`[Main] AI (${opponentType}) attempting to place tile ${tileToPlace.id} (orientation: ${tileToPlace.orientation}) at (${move.x}, ${move.y})`);
             if (placeTileOnBoard(tileToPlace, move.x, move.y)) {
@@ -1271,11 +1271,12 @@ function isSpaceEnclosed(q, r, currentBoardState) {
                 updateViewParameters();
                 animateView();
             } else {
+                // The error message now correctly reflects the orientation being used.
                 console.error(`[Main] AI (${opponentType}) failed to place tile ${tileToPlace.id} (orientation: ${tileToPlace.orientation}) at (${move.x}, ${move.y}). This should ideally be caught by worker's validation.`);
                 switchTurn();
             }
         } else {
-            console.log(`[Main] AI (${opponentType}) could not find any valid move or passed. Passing turn.`);
+            console.log(`[Main] AI (${opponentType}) could not find any valid move, passed, or move object was malformed. Passing turn. Move received:`, move);
             calculateScores();
             switchTurn();
         }


### PR DESCRIPTION
Standardized the structure of the move object returned by the AI worker for all AI types (random, greedy, greedy2) to be `{ tileId: string, orientation: number, x: number, y: number }`.

Updated `handleAiMoveResult` in `script.js` to correctly interpret this standardized move object, ensuring that `tileToPlace.orientation` is properly set from `move.orientation`.

This resolves an issue where the Greedy 2 AI would sometimes attempt to place a tile with an undefined orientation, leading to a placement error (often an edge mismatch) caught by the main thread's validation logic.