### PR TITLE
Enable drag and drop for player hand tiles to gameboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,26 +337,97 @@ footer {
     background-color: #d32f2f;
 }
 
-/* More specific styling for actual hexagons if using CSS clip-path or SVG */
-/* For example, using clip-path:
-.hex {
-    width: 100px;
-    height: 115.47px; // height = width / sqrt(3) * 2, or width * 1.1547
-    background-color: yellow;
-    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+/* Obsolete CSS related to DOM-based hexagon tiles and drop targets */
+/*
+.hexagon-tile {
+    width: 80px;
+    height: 92.38px;
+    background-color: #ccc;
     position: relative;
+    margin: 5px;
+    cursor: pointer;
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+    border: 1px solid #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 10px;
+    box-sizing: border-box;
 }
-This will be applied dynamically via JS or by having specific classes for tiles.
-*/
 
-/* Styling for selected tile */
-/* .hexagon-tile.selected { */
-    /* border: 3px solid gold; */ /* This is now handled by JS for canvas elements */
-    /* box-shadow: 0 0 10px gold; */ /* This is now handled by JS for canvas elements */
-/* } */
+.hexagon-tile.player1 {
+    background-color: lightblue;
+}
 
-/* Styling for potential drop zones on the board */
+.hexagon-tile.player2 {
+    background-color: lightcoral;
+}
+
+.hexagon-edge {
+    position: absolute;
+    width: 0;
+    height: 0;
+    box-sizing: border-box;
+}
+
+.edge-blank {
+}
+
+.edge-triangle {
+    width: 0;
+    height: 0;
+    border-left: 23.095px solid transparent;
+    border-right: 23.095px solid transparent;
+    border-bottom: 40.00px solid black;
+}
+
+.edge-0, .edge-1, .edge-2, .edge-3, .edge-4, .edge-5 {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+}
+.edge-0.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) translateY(-40px); }
+.edge-0.edge-triangle { transform: translate(-50%, -50%) translateY(-80px); }
+.edge-1.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) rotate(60deg) translateY(-40px); }
+.edge-1.edge-triangle { transform: translate(-50%, -50%) rotate(60deg) translateY(-80px); }
+.edge-2.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) rotate(120deg) translateY(-40px); }
+.edge-2.edge-triangle { transform: translate(-50%, -50%) rotate(120deg) translateY(-80px); }
+.edge-3.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) rotate(180deg) translateY(-40px); }
+.edge-3.edge-triangle { transform: translate(-50%, -50%) rotate(180deg) translateY(-80px); }
+.edge-4.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) rotate(240deg) translateY(-40px); }
+.edge-4.edge-triangle { transform: translate(-50%, -50%) rotate(240deg) translateY(-80px); }
+.edge-5.edge-blank { width: 37px; height: 2px; background-color: #555; transform: translate(-50%, -50%) rotate(300deg) translateY(-40px); }
+.edge-5.edge-triangle { transform: translate(-50%, -50%) rotate(300deg) translateY(-80px); }
+
+.edge {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    font-size: 12px;
+    text-align: center;
+    line-height: 10px;
+}
+.edge-0 { top: 0; left: 50%; transform: translateX(-50%); }
+.edge-1 { top: 25%; right: 0; transform: translateY(-50%) rotate(60deg); }
+.edge-2 { bottom: 25%; right: 0; transform: translateY(50%) rotate(120deg); }
+.edge-3 { bottom: 0; left: 50%; transform: translateX(-50%) rotate(180deg); }
+.edge-4 { bottom: 25%; left: 0; transform: translateY(50%) rotate(240deg); }
+.edge-5 { top: 25%; left: 0; transform: translateY(-50%) rotate(300deg); }
+
+.triangle::before {
+    content: "▲";
+}
+.blank::before {
+    content: " ";
+}
+
+.hexagon-tile.selected {
+    border: 3px solid gold;
+    box-shadow: 0 0 10px gold;
+}
+
 .drop-target {
-    background-color: rgba(0, 255, 0, 0.3); /* Light green highlight */
+    background-color: rgba(0, 255, 0, 0.3);
     border: 2px dashed green;
 }
+*/


### PR DESCRIPTION
- Added dragstart listener to canvas tiles in player's hand.
- Implemented dragover and drop listeners on the main game canvas.
- Drop handling reuses existing handleCellClick logic for placement and game progression.
- Visual feedback leverages existing selection styles and placement previews.
- Removed obsolete createTileElement function and associated CSS for old DOM-based tiles.