### PR TITLE
Fix: Reinstate setData for drag operation compatibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -508,7 +508,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
                 // For now, let's assume not appending it is fine as per MDN docs (it can be any canvas).
 
                 // Optionally, set data for drag event if needed elsewhere, though selectedTile might be sufficient.
-                // event.dataTransfer.setData('text/plain', tile.id);
+                event.dataTransfer.setData('text/plain', tile.id); // Crucial for Safari and can affect Chrome's drag icon
                 // event.target.style.opacity = '0.4'; // Example of making original more transparent
             });
 


### PR DESCRIPTION
This change reinstates `event.dataTransfer.setData('text/plain', tile.id);` in the `dragstart` event listener.

This resolves two issues:
1. In Chrome, the drag icon was defaulting to a generic "world" icon. It now correctly displays the rendered tile.
2. In Safari, drag-and-drop functionality was not working. It now works as expected.