### PR TITLE
Refactor: Improve AI's choice when removing its own surrounded tiles

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -629,7 +629,23 @@ function simulateRemovalCycle(initialBoardState, actingPlayerId) {
             }
             tileToRemove = bestRemovalChoice;
         } else if (ownTilesSurrounded.length > 0) {
-            tileToRemove = ownTilesSurrounded[0]; // Simplified: pick first own tile
+            // If AI must remove one of its own tiles, choose the one that is least damaging.
+            let bestOwnRemovalChoice = null;
+            // Initialize with a very low score, as we want to maximize the score (i.e., minimize the damage).
+            // Scores can be negative, so -Infinity is appropriate.
+            let scoreAfterOwnRemoval = -Infinity;
+
+            for (const ownTile of ownTilesSurrounded) {
+                const tempBoard = deepCopyBoardState(currentSimBoardState);
+                delete tempBoard[`${ownTile.x},${ownTile.y}`];
+                const currentScore = evaluateBoard(tempBoard, actingPlayerId);
+
+                if (currentScore > scoreAfterOwnRemoval) {
+                    scoreAfterOwnRemoval = currentScore;
+                    bestOwnRemovalChoice = ownTile;
+                }
+            }
+            tileToRemove = bestOwnRemovalChoice;
         }
 
         if (tileToRemove) {


### PR DESCRIPTION
Previously, when the AI's simulation (in `simulateRemovalCycle`) determined that one of its own tiles must be removed (due to no opponent tiles being surrounded), it would pick the first available tile.

This change modifies the logic to iterate through all such own surrounded tiles. For each, it simulates the removal and evaluates the resulting board score from the AI's perspective.

The AI now chooses to remove the tile that results in the highest (i.e., least damaging) score for itself, leading to more strategic defensive play during the tile removal phase of its move simulations.