### PR TITLE
Implement Greedy 4 mode for P2 AI

### DIFF
--- a/script.js
+++ b/script.js
@@ -1395,7 +1395,7 @@ function isSpaceEnclosed(q, r, currentBoardState) {
             animateView(); // Ensure animation loop is running for pulsing
             console.log("Tile removal phase. Surrounded tiles:", currentSurroundedTilesForRemoval.map(t => t.id));
 
-            if (currentPlayer === 2 && ['random', 'greedy', 'greedy2', 'greedy3'].includes(opponentType)) {
+            if (currentPlayer === 2 && ['random', 'greedy', 'greedy2', 'greedy3', 'greedy4'].includes(opponentType)) { // Added greedy4
                 // AI's turn and tiles are surrounded by its move, start AI removal process
                 console.log(`Player 2 (AI - ${opponentType}) is starting tile removal...`);
                 redrawBoardOnCanvas(); // Show highlights
@@ -1462,7 +1462,7 @@ function isSpaceEnclosed(q, r, currentBoardState) {
         renderPlayerHands();
 
         // Check if AI needs to make a move or remove a tile
-        const aiOpponentTypes = ['random', 'greedy', 'greedy2', 'greedy3'];
+        const aiOpponentTypes = ['random', 'greedy', 'greedy2', 'greedy3', 'greedy4']; // Added greedy4
         if (currentPlayer === 2 && !isRemovingTiles && aiOpponentTypes.includes(opponentType)) {
             console.log("Player 2 (AI) is thinking... (via switchTurn)");
             if (player2HandContainer) player2HandContainer.classList.add('ai-thinking-pulse');
@@ -1938,6 +1938,7 @@ function animateView() {
                         <option value="greedy">Greedy 1 (CPU)</option>
                         <option value="greedy2">Greedy 2 (CPU)</option>
                         <option value="greedy3">Greedy 3 (CPU)</option>
+                        <option value="greedy4">Greedy 4 (CPU)</option>
                     </select>
                 </div>
             </div>
@@ -1988,7 +1989,7 @@ function animateView() {
 
         // If it's Player 2's turn and a CPU opponent is selected, and not in removal phase,
         // let the AI make a move.
-        const aiOpponentTypes = ['random', 'greedy', 'greedy2', 'greedy3'];
+        const aiOpponentTypes = ['random', 'greedy', 'greedy2', 'greedy3', 'greedy4']; // Added greedy4
         if (currentPlayer === 2 && aiOpponentTypes.includes(opponentType) && !isRemovingTiles) {
             console.log("Player 2 (AI) is thinking... (opponent type changed)");
             if (player2HandContainer) player2HandContainer.classList.add('ai-thinking-pulse');


### PR DESCRIPTION
Adds a new 'Greedy 4' AI opponent type for Player 2, which uses a minimax algorithm with a depth of 3 (4-turn lookahead).

Modifications include:
- Updated `aiWorker.js` to handle depth 3 for Greedy 4 in `calculateGreedyMove` and refined AI tile removal logic.
- Updated `script.js` to add 'Greedy 4 (CPU)' to the opponent selection dropdown and include 'greedy4' in relevant AI type checks.