### PR TITLE
Fix: Correct variable name in Greedy 4 AI logic

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -293,7 +293,7 @@ var calculateGreedyMove = _asyncToGenerator(function* (boardState, player2Hand, 
         }
 
         if (minimaxResultPruned && minimaxResultPruned.moves && minimaxResultPruned.moves.length > 0) {
-            var chosenMinimaxMoveG3 = minimaxResultPruned.moves[Math.floor(Math.random() * minimaxResultPruned.moves.length)];
+            var chosenMinimaxMove = minimaxResultPruned.moves[Math.floor(Math.random() * minimaxResultPruned.moves.length)];
             bestMove = {
                 tileId: chosenMinimaxMove.tile.id,
                 orientation: chosenMinimaxMove.tile.orientation,


### PR DESCRIPTION
Resolved a TypeError that occurred when the Greedy 4 AI was calculating its move. The error was due to a variable name mismatch (`chosenMinimaxMoveG3` vs `chosenMinimaxMove`).