### PR TITLE
Fix: Trigger popped tile vibration on tap, not after animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,12 +170,6 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
             // This is the callback function, executed after animation completes.
             console.log(`Animation complete for tile ${tileToRemove.id}. Finalizing removal.`);
 
-            // Vibrate on mobile if API is available
-            if (navigator.maxTouchPoints > 0 && typeof navigator.vibrate === 'function') {
-                navigator.vibrate(100); // Vibrate for 100ms
-                console.log("Device vibrated on tile removal.");
-            }
-
             // Restore tile to boardState if it was only temporarily removed for redrawing.
             // Actually, the plan is to remove it from boardState *after* animation.
             // The delete operation above was temporary. So, if it's still in originalTileData,
@@ -2066,6 +2060,13 @@ function animateView() {
 
             if (clickedTile && currentSurroundedTilesForRemoval.some(st => st.id === clickedTile.id)) {
                 // Valid tile selected for removal
+
+                // Vibrate on mobile if API is available (MOVED HERE)
+                if (navigator.maxTouchPoints > 0 && typeof navigator.vibrate === 'function') {
+                    navigator.vibrate(100); // Vibrate for 100ms
+                    console.log("Device vibrated on tile tap for removal."); // Updated log message
+                }
+
                 removeTileFromBoardAndReturnToHand(clickedTile);
             } else {
                 console.log("Invalid selection. Click on a highlighted (surrounded) tile to remove it.");


### PR DESCRIPTION
Moved the haptic feedback for popped tiles to occur immediately when a surrounded tile is tapped on the board, rather than after the tile finishes its animation back to the player's hand.