### PR TITLE
Fix: Prevent vertical stretching of hand tiles in single row

### DIFF
--- a/style.css
+++ b/style.css
@@ -198,6 +198,7 @@ main {
     min-height: 100px; /* To give some space even when empty */
     padding: 10px;
     border: 1px dashed #ccc;
+    align-items: flex-start; /* Prevent vertical stretching of tiles */
     border-radius: 4px;
 }
 


### PR DESCRIPTION
Added `align-items: flex-start;` to the `.tiles-container` CSS rule. This prevents flex items (tile canvases) from being stretched vertically when the container is taller than a single row of tiles, resolving the 'squished' tile appearance.