### PR TITLE
Fix: Replace undefined calculateScores with calculateAndUpdateTotalSc…

### DIFF
--- a/script.js
+++ b/script.js
@@ -1440,7 +1440,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
             } else {
             isRemovingTiles = false;
             isPulsingGlobal = false; // Ensure pulsing stops if no tiles were surrounded initially
-                calculateScores(); // Update scores after each turn
+                calculateAndUpdateTotalScores(); // Update scores after each turn
                 switchTurn(); // Always switch turn, game end is checked at the start of the next turn
             }
         }


### PR DESCRIPTION
…ores

The function `calculateScores` was called in `checkForSurroundedTilesAndProceed` but it was not defined, leading to a ReferenceError when playing against the AI and when no tiles were surrounded after a move.

This commit replaces the call to `calculateScores()` with the existing function `calculateAndUpdateTotalScores()` which correctly updates the game scores and UI.