### PR TITLE
Fix: Resolve ReferenceError for animateScoreUpdateOnBoard

### DIFF
--- a/script.js
+++ b/script.js
@@ -1377,7 +1377,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
 
                 // Wait for highlight to roughly finish before starting +1 animations for better sequence
                 setTimeout(() => {
-                    animateScoreUpdateOnBoard(currentPlayer, scoreDelta, matchedPairs, () => {
+                    animateScoreChangeOnBoard(currentPlayer, matchedPairs, "+1", () => {
                         // Callback after +1 animations on board are done
                         animateScoreboardUpdate(currentPlayer, newPlayerScore, oldPlayerScore, () => {
                             // Callback after scoreboard animation is done


### PR DESCRIPTION
The function `animateScoreUpdateOnBoard` was called but not defined. This commit replaces the call with the existing and correctly defined function `animateScoreChangeOnBoard`, and adjusts the parameters accordingly (changing `scoreDelta` to the string `"+1"` for the `textToShow` parameter).

This resolves the ReferenceError encountered when a player scores points, particularly noted during gameplay involving the greedy6 AI.