### PR TITLE
Fix: AI evaluation highlight only shows valid placements

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -412,17 +412,17 @@ var calculateGreedyMove = _asyncToGenerator(function* (boardState, player2Hand, 
                 for (var i_ps = 0; i_ps < placementSpots.length; i_ps++) {
                     var pos = placementSpots[i_ps];
 
-                    // For Greedy 1, send evaluation message here
-                    self.postMessage({
-                        task: 'aiEvaluatingMove',
-                        moveData: {
-                            tile: { id: tile.id, playerId: tile.playerId, edges: [].concat(tile.edges), orientation: tile.orientation },
-                            x: pos.x,
-                            y: pos.y
-                        }
-                    });
-
                     if (isPlacementValid(tile, pos.x, pos.y, boardState, true, effectiveDebug)) { // Pass effectiveDebug
+                        // For Greedy 1, send evaluation message here, *after* validation
+                        self.postMessage({
+                            task: 'aiEvaluatingMove',
+                            moveData: {
+                                tile: { id: tile.id, playerId: tile.playerId, edges: [].concat(tile.edges), orientation: tile.orientation },
+                                x: pos.x,
+                                y: pos.y
+                            }
+                        });
+
                         var tempBoardState = deepCopyBoardState(boardState);
                         var simTile = new HexTile(tile.id, tile.playerId, tile.edges);
                         simTile.orientation = tile.orientation;


### PR DESCRIPTION
The AI worker, specifically the Greedy 1 strategy, was previously sending messages to highlight potential moves before confirming they were valid. This change moves the message dispatch to after the validity check, ensuring that the UI only shows highlights for placements the AI considers valid.