### PR TITLE
Refactor: Display end game states as a banner instead of an alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
             </div>
         </div>
 
+        <div id="game-over-banner" class="hidden"></div>
+
         <div id="player-hands">
             <!-- Player hand divs will be dynamically added here by script.js -->
         </div>

--- a/script.js
+++ b/script.js
@@ -17,6 +17,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
     // const player2ScoreDisplay = document.getElementById('player2-score'); // Removed
     const playerScoresContainer = document.getElementById('player-scores'); // New container for scores
     let p1ScoreDisplayFloater, p2ScoreDisplayFloater; // Will be created dynamically
+    const gameOverBanner = document.getElementById('game-over-banner'); // Added for game over banner
 
     const resetGameButton = document.getElementById('reset-game');
     // player1HandContainer and player2HandContainer will be created dynamically
@@ -1095,6 +1096,12 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         // gameMessageDisplay.textContent = "Player 1's turn. Select a tile and place it on the board."; // Removed
         console.log("Player 1's turn. Select a tile and place it on the board.");
 
+        // Hide the game over banner
+        if (gameOverBanner) {
+            gameOverBanner.classList.add('hidden');
+            // Or gameOverBanner.style.display = 'none';
+        }
+
         gameInitialized = true;
         console.log("Game initialized. Player 1 hand:", player1Hand, "Player 2 hand:", player2Hand);
 
@@ -1973,8 +1980,15 @@ function isSpaceEnclosed(q, r, currentBoardState) {
         console.log(`Game Over! ${detailedMessage}`);
         console.log("Game ended. ", detailedMessage);
 
-        // Display the celebratory message to the user
-        alert(celebratoryMessage);
+        // Display the celebratory message to the user using the banner
+        if (gameOverBanner) {
+            gameOverBanner.textContent = celebratoryMessage;
+            gameOverBanner.classList.remove('hidden');
+            // Or gameOverBanner.style.display = 'block'; if not using class toggling for visibility
+        } else {
+            // Fallback if banner element isn't found for some reason
+            alert(celebratoryMessage);
+        }
 
         // Disable further moves, or handle via selectedTile being null / hands empty
     }

--- a/style.css
+++ b/style.css
@@ -37,6 +37,25 @@ main {
     /* display: inline-block; might be useful if canvas is also inline-block and we want them to size together */
 }
 
+#game-over-banner {
+    text-align: center;
+    padding: 20px;
+    background-color: rgba(0, 0, 0, 0.75);
+    color: white;
+    font-size: 1.5em;
+    font-weight: bold;
+    border-radius: 8px;
+    margin: 20px auto;
+    width: 80%; /* Or a specific max-width */
+    max-width: 600px;
+    z-index: 100;
+    /* Initially hidden by the .hidden class */
+}
+
+.hidden {
+    display: none !important; /* Important to override other display styles if needed */
+}
+
 /* Removed #game-info styles */
 
 #player-scores {


### PR DESCRIPTION
Replaced the JavaScript alert for game end states (win, loss, tie) with a dynamically appearing HTML banner positioned above the player hands.

- Added a new div#game-over-banner in index.html.
- Styled the banner in style.css for appearance and initial hidden state.
- Modified script.js:
    - endGame function now updates and shows the banner.
    - initializeGame function now hides the banner.