### PR TITLE
Fix: Correct function call for score calculation in endGame

### DIFF
--- a/script.js
+++ b/script.js
@@ -1989,7 +1989,7 @@ function isSpaceEnclosed(q, r, currentBoardState) {
     }
 
     function endGame() {
-        calculateScores();
+        calculateAndUpdateTotalScores();
         let celebratoryMessage = "";
 
         if (player1Score > player2Score) { // Player 1 wins


### PR DESCRIPTION
The endGame function was attempting to call `calculateScores()`, which is not defined. This change corrects the call to `calculateAndUpdateTotalScores()`, which is the intended function for calculating and updating the final game scores before determining the winner.