### PR TITLE
Fix: Prevent boardState reset when loading from URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -569,8 +569,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         ctx.strokeStyle = '#aaa'; // Same as old #game-board border
         ctx.strokeRect(0, 0, gameCanvas.width, gameCanvas.height);
 
-
-        boardState = {}; // Reset board state
+        // boardState = {}; // Reset board state // <--- THIS LINE IS REMOVED to preserve loaded state
         // The old cell creation loop is removed.
         // Event listeners for drag/drop on cells are removed.
         // Click handling will be added directly to the canvas later.


### PR DESCRIPTION
The game board was appearing blank when loading a game state from the URL. This was because `initializeGameBoard` was unconditionally resetting `boardState = {}` after the state had been loaded from the URL parameters.

This change removes the erroneous `boardState = {}` line from `initializeGameBoard`, ensuring that the loaded board configuration is preserved and subsequently rendered by `redrawBoardOnCanvas`.