### PR TITLE
Fix: Game board renders correctly when loading state from URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -625,7 +625,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         ctx.strokeRect(0, 0, gameCanvas.width, gameCanvas.height);
 
 
-        boardState = {}; // Reset board state
+        // boardState = {}; // Reset board state // <--- THIS LINE IS REMOVED to preserve loaded state
         // The old cell creation loop is removed.
         // Event listeners for drag/drop on cells are removed.
         // Click handling will be added directly to the canvas later.


### PR DESCRIPTION
Previously, the `initializeGameBoard` function would unconditionally reset the `boardState`, clearing any state loaded from the URL. This change removes the line that resets `boardState` in `initializeGameBoard`, allowing the loaded tiles to be drawn correctly.