### PR TITLE
Refactor: Remove player hand switch animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,40 +140,11 @@ main {
     width: 90%; /* Make hands wider */
     max-width: 800px; /* Optional: prevent it from becoming too wide on very large screens */
     transition: opacity 0.3s ease, box-shadow 0.3s ease; /* Smooth transition for changes */
-    position: relative; /* Needed for z-index and potential absolute positioning during animation */
+    position: relative; /* Needed for z-index */
 }
 
-.player-hand.sweeping-out {
-    animation: sweep-out-below 0.5s forwards ease-in-out;
-    z-index: 0; /* Ensure outgoing hand is below incoming */
-}
-
-.player-hand.rising-in {
-    animation: rise-in-from-below 0.5s forwards ease-in-out;
-    z-index: 1; /* Ensure incoming hand is above outgoing */
-}
-
-@keyframes sweep-out-below {
-    0% {
-        transform: translateY(0);
-        opacity: 1;
-    }
-    100% {
-        transform: translateY(100%); /* Move down */
-        opacity: 0;
-    }
-}
-
-@keyframes rise-in-from-below {
-    0% {
-        transform: translateY(100%); /* Start from below */
-        opacity: 0;
-    }
-    100% {
-        transform: translateY(0);
-        opacity: 1;
-    }
-}
+/* Removed .player-hand.sweeping-out and .player-hand.rising-in styles */
+/* Removed @keyframes sweep-out-below and @keyframes rise-in-from-below */
 
 .player-hand.active-hand {
     opacity: 1;


### PR DESCRIPTION
- Modified `renderPlayerHands` in `script.js` to directly swap player hand containers without CSS animations.
- Removed unused CSS keyframes (`sweep-out-below`, `rise-in-from-below`) and associated class styles from `style.css`.

The player hand transition is now instantaneous, with the current player's hand appearing on top.