### PR TITLE
Feat: Add toast notification for tile rotation reminder

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
         <button id="reset-game">Reset Game</button>
     </footer>
 
+    <div id="toast-notification" class="toast hidden"></div>
+
     <script src="script.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/script.js
+++ b/script.js
@@ -58,6 +58,10 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
     let currentlyHighlightedTriangles = []; // For score animation highlights
     let activeScoreAnimations = []; // For "+1" animations on the board
 
+    // State variables for toast notification logic
+    let isFirstTurn = true;
+    let playerHasRotatedTileThisGame = {1: false, 2: false};
+
     // --- Tile Representation ---
     // Edge types: 0 for blank, 1 for triangle
     // Edges are ordered clockwise starting from the top edge.
@@ -1081,6 +1085,7 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         if (!loadedState || isReset) { // If no state loaded from URL OR if it's a reset, initialize a new game
             console.log("No valid game state in URL or loading failed. Initializing a new game.");
             player1Hand = generateUniqueTilesForPlayer(1, NUM_TILES_PER_PLAYER);
+            player1Hand = generateUniqueTilesForPlayer(1, NUM_TILES_PER_PLAYER);
             player2Hand = generateUniqueTilesForPlayer(2, NUM_TILES_PER_PLAYER);
             currentPlayer = 1;
             player1Score = 0;
@@ -1092,6 +1097,10 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
             lastPlacedTileKey = null;
             aiEvaluatingDetails = null;
             opponentType = "greedy"; // Default opponent type for new games
+
+            // Initialize toast notification state variables
+            isFirstTurn = true;
+            playerHasRotatedTileThisGame = {1: false, 2: false};
         }
 
         // Common initialization steps regardless of new or loaded game:
@@ -1371,7 +1380,8 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         if (selectedTile && selectedTile.tile.id === tile.id && !isDragStart) {
             // Tile is already selected, and this is not a drag initiation, so rotate it
             selectedTile.tile.rotate();
-            console.log(`Tile ${selectedTile.tile.id} rotated by clicking. New orientation: ${selectedTile.tile.orientation}`);
+            playerHasRotatedTileThisGame[currentPlayer] = true; // Update rotation tracker
+            console.log(`Tile ${selectedTile.tile.id} rotated by clicking. Player ${currentPlayer} has now rotated. New orientation: ${selectedTile.tile.orientation}`);
 
             // Re-draw the selected tile in the hand
             const tileCtx = tileCanvasElement.getContext('2d');
@@ -1419,6 +1429,19 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
             }
             console.log("Selected tile for interaction (click or drag):", selectedTile);
             updatePlacementHighlights(); // Update highlights for board placement
+
+            // Toast notification logic
+            if (!isDragStart) { // Only show toast on actual click selection, not drag start
+                const currentTileEdges = tile.getOrientedEdges().toString();
+                const allTrianglesPattern = UNIQUE_TILE_PATTERNS[UNIQUE_TILE_PATTERNS.length - 1].toString();
+                const allBlanksPattern = UNIQUE_TILE_PATTERNS[0].toString();
+
+                const isSpecialTile = currentTileEdges === allTrianglesPattern || currentTileEdges === allBlanksPattern;
+
+                if (!isFirstTurn && !playerHasRotatedTileThisGame[currentPlayer] && !isSpecialTile) {
+                    showToast("Tap again to rotate the tile.");
+                }
+            }
         }
     }
 
@@ -1427,7 +1450,8 @@ let player2HandDisplay = document.querySelector('#player2-hand .tiles-container'
         if (event.key === 'r' || event.key === 'R') {
             if (selectedTile && selectedTile.tile && selectedTile.handElement) {
                 selectedTile.tile.rotate();
-                console.log(`Tile ${selectedTile.tile.id} rotated. New orientation: ${selectedTile.tile.orientation}`);
+                playerHasRotatedTileThisGame[currentPlayer] = true; // Update rotation tracker
+                console.log(`Tile ${selectedTile.tile.id} rotated by keypress. Player ${currentPlayer} has now rotated. New orientation: ${selectedTile.tile.orientation}`);
 
                 // Re-draw the selected tile in the hand
                 const tileCanvas = selectedTile.handElement;
@@ -1570,6 +1594,13 @@ function processSuccessfulPlacement(placedTileKey, playerOfTurn) {
         // Visual update will be handled by a dedicated drawing function that iterates boardState
         // and draws all tiles on the canvas. This function will be called after successful placement.
         console.log(`Tile ${tile.id} placed at ${x},${y}. Board state updated. Last placed key: ${lastPlacedTileKey}`);
+
+        // Update isFirstTurn state variable
+        if (isFirstTurn) {
+            isFirstTurn = false;
+            console.log("First turn is now complete.");
+        }
+
         redrawBoardOnCanvas(); // Redraw the entire board with the new tile
 
         // const cell = getBoardCell(x,y); // Obsolete
@@ -2570,6 +2601,31 @@ function animateView() {
     // Call it once initially after game setup might also be good,
     // or ensure initializeGame's call to updateViewParameters is sufficient.
     // Let's add it at the end of initializeGame.
+
+    // --- Toast Notification Functionality ---
+    let toastTimeout = null; // To manage the timeout for hiding the toast
+
+    function showToast(message) {
+        const toastElement = document.getElementById('toast-notification');
+        if (!toastElement) {
+            console.error("Toast notification element not found.");
+            return;
+        }
+
+        toastElement.textContent = message;
+        toastElement.classList.add('show');
+
+        // Clear any existing timeout to prevent premature hiding if called multiple times
+        if (toastTimeout) {
+            clearTimeout(toastTimeout);
+        }
+
+        // Hide the toast after 3 seconds (or your preferred duration)
+        toastTimeout = setTimeout(() => {
+            toastElement.classList.remove('show');
+            toastTimeout = null; // Clear the timeout ID
+        }, 3000);
+    }
 
     // --- Canvas Click Handling ---
     gameCanvas.addEventListener('click', (event) => {

--- a/style.css
+++ b/style.css
@@ -470,3 +470,34 @@ footer {
     border: 2px dashed green;
 }
 */
+
+/* Toast Notification Styles */
+.toast {
+    visibility: hidden; /* Use visibility to manage state for animations */
+    min-width: 250px;
+    margin-left: -125px;
+    background-color: #333;
+    color: #fff;
+    text-align: center;
+    border-radius: 2px;
+    padding: 16px;
+    position: fixed;
+    z-index: 1001; /* Above other elements, but below modal if any */
+    left: 50%;
+    bottom: 30px;
+    font-size: 17px;
+    opacity: 0; /* Start fully transparent */
+    transition: opacity 0.5s, visibility 0s 0.5s; /* Delay visibility transition until opacity is done */
+}
+
+.toast.show {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s; /* Fade in */
+}
+
+/* .hidden class is already defined and uses display: none !important;
+   We are using visibility and opacity for the toast for smoother transitions.
+   If .hidden were applied to the toast, it would override the visibility.
+   The JS will manage adding/removing a 'show' class instead.
+*/


### PR DESCRIPTION
Implemented a toast notification that reminds players to tap a selected tile again to rotate it.

The toast appears if:
- It's not the first turn of the game.
- The current player has not yet rotated a tile in this game session.
- The selected tile is not one of the special tiles (all triangles or all blanks) where rotation has no visual effect.

The feature tracks tile rotation status independently for each player.