### PR TITLE
Fix: Ensure header remains fixed on mobile scroll

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,19 @@
-body {
-    font-family: Arial, sans-serif;
+html, body {
+    height: 100%;
     margin: 0;
     padding: 0;
+    overflow-x: hidden; /* Prevents horizontal scrollbars which can sometimes interfere */
+}
+
+body {
+    font-family: Arial, sans-serif;
+    /* margin: 0; and padding: 0; are now in the html, body rule */
     background-color: #f0f0f0;
     color: #333;
     display: flex;
     flex-direction: column;
     align-items: center;
+    /* height: 100%; is now in the html, body rule */
 }
 
 /* Styles for the fixed "Xago" text */


### PR DESCRIPTION
Applied `height: 100%` and `overflow-x: hidden` to `html` and `body` elements in `style.css`. This change stabilizes the `position: fixed` behavior of the header on mobile devices, preventing it from sliding up and being clipped during page scroll.