### PR TITLE
Fix: Preserve move type and original coordinates in AI decision making

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -1380,10 +1380,26 @@ function findBestMoveMinimax(currentBoardState, aiHandOriginal, opponentHandOrig
             if (currentTurnEval > maxEval) {
                 if (effectiveDebug) console.log("[Worker DEBUG] findBestMoveMinimax (Maximizing, Depth: " + depth + "): New best score. Old maxEval:", maxEval, "New:", currentTurnEval);
                 maxEval = currentTurnEval;
-                bestMoves = [{ tile: {id: move.tile.id, playerId: currentPlayerForThisTurn, edges: [].concat(move.tile.edges), orientation: move.orientation}, x: move.x, y: move.y, score: maxEval }];
+                bestMoves = [{
+                    type: move.type,
+                    tile: {id: move.tile.id, playerId: currentPlayerForThisTurn, edges: [].concat(move.tile.edges), orientation: move.orientation},
+                    x: move.x,
+                    y: move.y,
+                    originalX: move.originalX,
+                    originalY: move.originalY,
+                    score: maxEval
+                }];
             } else if (currentTurnEval === maxEval) {
                 if (effectiveDebug) console.log("[Worker DEBUG] findBestMoveMinimax (Maximizing, Depth: " + depth + "): Equal best score. Score:", currentTurnEval);
-                bestMoves.push({ tile: {id: move.tile.id, playerId: currentPlayerForThisTurn, edges: [].concat(move.tile.edges), orientation: move.orientation}, x: move.x, y: move.y, score: maxEval });
+                bestMoves.push({
+                    type: move.type,
+                    tile: {id: move.tile.id, playerId: currentPlayerForThisTurn, edges: [].concat(move.tile.edges), orientation: move.orientation},
+                    x: move.x,
+                    y: move.y,
+                    originalX: move.originalX,
+                    originalY: move.originalY,
+                    score: maxEval
+                });
             }
             var oldAlpha = alpha;
             alpha = Math.max(alpha, currentTurnEval);


### PR DESCRIPTION
Previously, the `findBestMoveMinimax` function did not include the `type`, `originalX`, and `originalY` fields in the move objects it returned. This caused 'move' actions chosen by Greedy 2 and Greedy 4 AIs to be misinterpreted as 'place' actions, as the type would default to 'place'.

This commit modifies `findBestMoveMinimax` to correctly include these fields in the `bestMoves` array it constructs. This ensures that the AI's chosen action type and any associated original coordinates (for moves) are accurately propagated for correct execution in `script.js`.