### PR TITLE
Fix: Center toast notification using transform

### DIFF
--- a/style.css
+++ b/style.css
@@ -512,7 +512,8 @@ footer {
 .toast {
     visibility: hidden; /* Use visibility to manage state for animations */
     min-width: 250px;
-    margin-left: -125px;
+    /* margin-left: -125px; */ /* Removed for transform-based centering */
+    transform: translateX(-50%); /* Added for robust centering */
     background-color: #333;
     color: #fff;
     text-align: center;


### PR DESCRIPTION
The toast notification was previously centered using a fixed `margin-left` value, which caused it to be off-center if the toast content had a different width.

This commit updates the CSS to use `transform: translateX(-50%)` for robust horizontal centering, ensuring the toast remains centered regardless of its width.