### PR TITLE
Fix: Correct tile aspect ratio on mobile portrait scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -3162,8 +3162,9 @@ function animateView() {
             gameCanvas.width = windowWidth; // Set backing store size
             gameCanvas.style.width = '100%'; // Canvas takes 100% of gameboardArea
 
-            gameCanvas.height = windowHeight * 0.5; // Set backing store size
-            gameCanvas.style.height = '50vh'; // Use vh for 50% viewport height
+            // Set canvas height equal to its width for a 1:1 aspect ratio in portrait mode
+            gameCanvas.height = gameCanvas.width;
+            gameCanvas.style.height = gameCanvas.width + 'px';
 
             gameCanvas.style.margin = "0 auto"; // Remove top/bottom margin, keep auto for horizontal centering
             gameboardArea.style.marginTop = "0"; // Ensure container also has no top margin


### PR DESCRIPTION
Previously, tiles on the gameboard could appear squished (stretched vertically) in mobile portrait layout, especially when scrolled to the top of the page. This was due to the canvas height being tied to viewport height units (vh) or window.innerHeight, which can fluctuate with browser UI elements (e.g., address bar) appearing/disappearing on scroll.

This commit modifies the `resizeCanvas` function in `script.js`. In portrait mode, the canvas height is now set equal to its width. This ensures a consistent 1:1 aspect ratio for the canvas element itself, providing a stable area for `updateViewParameters` to calculate zoom levels. This change results in correctly proportioned tiles regardless of scroll position.