### PR TITLE
Fix: Correctly handle highlight previews for tiles with rotational sy…

### DIFF
--- a/script.js
+++ b/script.js
@@ -1394,9 +1394,12 @@ function getCookie(name) {
         const greenSpots = new Set();
         const yellowSpots = new Map();
 
+    const uniqueOrientations = getUniqueOrientations(tileToPlace);
+    const numUniqueOrientations = uniqueOrientations.length;
+
         for (const placement of placements) {
             const key = `${placement.x},${placement.y}`;
-            if (placement.orientation === currentSelectedOrientation) {
+        if (currentSelectedOrientation % (6 / numUniqueOrientations) === placement.orientation % (6 / numUniqueOrientations)) {
                 greenSpots.add(key);
             } else {
                 if (!yellowSpots.has(key)) {


### PR DESCRIPTION
…mmetry

The previous implementation did not correctly handle highlight previews for tiles with rotational symmetry. This was because the `getAllPossiblePlacements` function only checked for unique orientations. This caused the highlight previews to be yellow when the tile was rotated, which was incorrect.

This commit fixes the issue by:
- Modifying `updatePlacementHighlights` to use the number of unique orientations to determine if a placement is valid for the current orientation.