### PR TITLE
feat(ai): Sort AI moves by triangle count, tile ID, and position

### DIFF
--- a/aiWorker.js
+++ b/aiWorker.js
@@ -496,6 +496,25 @@ function findBestMoveMinimax(currentBoardState, aiHandOriginal, opponentHandOrig
 
     var possibleMoves = getAllPossibleOptions(currentBoardState, handForCurrentPlayer, currentPlayerForThisTurn, gameMode, effectiveDebug);
 
+    // Sort moves to improve pruning and user experience.
+    possibleMoves.sort((a, b) => {
+        const trianglesA = countTriangles(a.tile);
+        const trianglesB = countTriangles(b.tile);
+        if (trianglesA !== trianglesB) {
+            return trianglesB - trianglesA; // Primary sort: higher triangles first
+        }
+
+        if (a.tile.id !== b.tile.id) {
+            return a.tile.id - b.tile.id; // Secondary sort: tile ID
+        }
+
+        if (a.x !== b.x) {
+            return a.x - b.x; // Tertiary sort: position x
+        }
+
+        return a.y - b.y; // Quaternary sort: position y
+    });
+
     if (possibleMoves.length === 0) {
         return { score: evaluateBoard(currentBoardState, aiPlayerId), moves: [] };
     }


### PR DESCRIPTION
This change modifies the `findBestMoveMinimax` function in `aiWorker.js` to sort the possible moves by:
1. Number of triangles (descending)
2. Tile ID (ascending)
3. Position (x, then y, ascending)

This will cluster all options that involve a specific tile in a specific place, which should improve alpha-beta pruning efficiency, lead to a more coherent "ghost tile" experience for you, and potentially increase cache hits for board layout-based logic checks.