### PR TITLE
Add Kickstarter link to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
     <footer>
         <button id="reset-game">Reset Game</button>
+        <a href="https://www.kickstarter.com/projects/akdotcom/xago" target="_blank" id="kickstarter-link">Like Xago? Back the Kickstarter campaign!</a>
     </footer>
 
     <div id="toast-notification" class="toast"></div>

--- a/style.css
+++ b/style.css
@@ -409,6 +409,18 @@ footer {
     background-color: #d32f2f;
 }
 
+#kickstarter-link {
+    margin-left: 20px;
+    vertical-align: middle;
+    text-decoration: none;
+    color: #0573e0;
+    font-weight: bold;
+}
+
+#kickstarter-link:hover {
+    text-decoration: underline;
+}
+
 /* Obsolete CSS related to DOM-based hexagon tiles and drop targets */
 /*
 .hexagon-tile {


### PR DESCRIPTION
This change adds a link to the Xago Kickstarter campaign in the footer of the page, as requested. The link is placed next to the "Reset Game" button and styled to match the game's theme. Visual verification has been performed to ensure correct placement and styling.

---
*PR created automatically by Jules for task [11797696741796234882](https://jules.google.com/task/11797696741796234882) started by @akdotcom*